### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # cleed
 
 Simple feed reader for the command line.


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=radulucut&project=cleed&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
