### PR TITLE
feat: add parsed object cache to optimize -C flag performance

### DIFF
--- a/internal/feed.go
+++ b/internal/feed.go
@@ -402,6 +402,7 @@ func (f *TerminalFeed) processFeeds(opts *FeedOptions, config *storage.Config, s
 				ci.ETag = res.ETag
 				ci.LastFetch = f.time.Now()
 				summary.FeedsFetched++
+				f.storage.SaveParsedFeedCache(feed, url)
 			} else {
 				summary.FeedsCached++
 			}
@@ -427,6 +428,9 @@ func (f *TerminalFeed) tokenizeItem(item *gofeed.Item) [][]rune {
 }
 
 func (f *TerminalFeed) parseFeed(url string) (*gofeed.Feed, error) {
+	if f.storage.HasParsedFeedCache(url) {
+		return f.storage.LoadParsedFeedCache(url)
+	}
 	fc, err := f.storage.OpenFeedCache(url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# PR Summary

## Optimize cached-only operations with parsed object cache

**Problem:** The `-C` (cached-only) flag still required XML parsing of cached feeds, which could be slow for large feeds or when processing many feeds offline.

**Solution:** Implement a dual cache strategy that stores both raw XML and pre-parsed `gofeed.Feed` objects.

## Changes

- **New cache methods in `LocalStorage`:**
  - `SaveParsedFeedCache()` - serialize `gofeed.Feed` objects using gob encoding
  - `LoadParsedFeedCache()` - deserialize cached feed objects 
  - `HasParsedFeedCache()` - check if parsed cache exists

- **Updated feed processing:**
  - `parseFeed()` now checks parsed cache first, falls back to XML parsing
  - Parsed objects automatically cached when feeds are fetched and changed
  - `RemoveFeedCaches()` removes both raw and parsed cache files

## Performance Benefits

- **Eliminates XML parsing** for `-C` operations when parsed cache exists
- **Seamless fallback** to XML parsing when parsed cache unavailable
- **Full flag compatibility** - search, list, since, limit all work identically

## Cache Structure

```
cache/
├── feed_<encoded-url> # Raw XML (preserved)
├── parsed_<encoded-url> # Parsed objects (new)
└── cache_info # Metadata (unchanged)
```

## Backward Compatibility

- Zero breaking changes - existing cache files continue to work
- Raw XML preserved for debugging and fallback scenarios  
- All existing functionality and flags work identically
